### PR TITLE
Fix issue with modal content buttons not responding on some Android devices

### DIFF
--- a/src/components/DraggableView.js
+++ b/src/components/DraggableView.js
@@ -138,9 +138,11 @@ export default class DraggableView extends Component<Props> {
   }
 
   panResponder = PanResponder.create({
-    onMoveShouldSetPanResponder: (evt, gestureState) => (
-      gestureState.dx !== 0 && gestureState.dy !== 0
-    ),
+    onMoveShouldSetPanResponder: (evt, gestureState) => {
+      const { dx, dy } = gestureState
+
+      return dx > 2 || dx < -2 || dy > 2 || dy < -2
+    },
     onStartShouldSetPanResponder: () => true,
     onPanResponderMove: (event, gestureState) => {
       const isVerticalSwipe = d => ['up', 'down'].includes(d);


### PR DESCRIPTION
https://github.com/jacklam718/react-native-modals/issues/208

The solution is to decrease DraggableView component PanResponder on touch start sensitivity https://stackoverflow.com/a/52609793

Tested it on real devices both Android and iOS and everything works as expected (pressing buttons inside content and swiping out modal with gesture).