### PR TITLE
Remove the "Require cycle" warning

### DIFF
--- a/src/components/ModalButton.js
+++ b/src/components/ModalButton.js
@@ -3,7 +3,17 @@
 import React from 'react';
 import { Text, PixelRatio, TouchableHighlight, StyleSheet, Platform } from 'react-native';
 import { Positions } from '../constants/Constants';
-import type { ModalButtonProps } from '../type';
+
+type ModalButtonProps = {
+  text: string,
+  onPress: () => void,
+  align?: string,
+  style?: any,
+  textStyle?: any,
+  disabled?: boolean,
+  activeOpacity?: number,
+  bordered?: boolean,
+};
 
 const isAndroid = Platform.OS === 'android';
 
@@ -61,3 +71,4 @@ const ModalButton = ({
 };
 
 export default ModalButton;
+export type { ModalButtonProps };

--- a/src/type.js
+++ b/src/type.js
@@ -2,6 +2,7 @@
 
 import { type Element, type Node } from 'react';
 import ModalButton from './components/ModalButton';
+export type { ModalButtonProps } from './components/ModalButton';
 
 export type SwipeDirection = 'up' | 'down' | 'left' | 'right'
 
@@ -54,17 +55,6 @@ export type ModalFooterActionList = Array<Element<typeof ModalButton>>;
 export type modalFooterProps = {
   children: ModalFooterActionList;
   style?: any;
-  bordered?: boolean;
-}
-
-export type ModalButtonProps = {
-  text: string;
-  onPress: () => void;
-  align?: string;
-  style?: any;
-  textStyle?: any;
-  disabled?: boolean;
-  activeOpacity?: number;
   bordered?: boolean;
 }
 


### PR DESCRIPTION
Instead of moving ModalButton.js into type.js, I deleted ModalButtonProps in type.js, and moved it to ModalButton.js. It might not be a good solution, but it works anyway.