### PR TITLE
Disable pointer events on modal when swiping out

### DIFF
--- a/src/components/BaseModal.js
+++ b/src/components/BaseModal.js
@@ -229,7 +229,7 @@ class BaseModal extends Component<ModalProps, State> {
           basFooter: !!footer,
         }}
       >
-        <View style={[styles.container, hidden]}>
+        <View pointerEvents={this.isSwipingOut ? 'none' : 'auto'} style={[styles.container, hidden]}>
           <DraggableView
             style={StyleSheet.flatten([styles.draggableView, style])}
             onMove={this.handleMove}


### PR DESCRIPTION
This small change allows the user to scroll on a ScrollView or similar underneath a Modal right after the swipeOut gesture is complete, instead of having to wait for the animation to complete.